### PR TITLE
Removed smallestUndimmedDetentIdentifier 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ BottomSheet can be customized in the same way a UISheetPresentationController ca
     isPresented: $isPresented,
     detents: [.medium(), .large()],
     prefersGrabberVisible: true,
-    smallestUndimmedDetentIdentifier: nil,
     prefersScrollingExpandsWhenScrolledToEdge: true,
     prefersEdgeAttachedInCompactHeight: false,
     widthFollowsPreferredContentSizeWhenEdgeAttached: false

--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -11,6 +11,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
     @Binding private var isPresented: Bool
     private let detents: [UISheetPresentationController.Detent]
     private let prefersGrabberVisible: Bool
+    private let largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier?
     private let prefersScrollingExpandsWhenScrolledToEdge: Bool
     private let prefersEdgeAttachedInCompactHeight: Bool
     private let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
@@ -22,6 +23,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         isPresented: Binding<Bool>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
+        largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -30,6 +32,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         _isPresented = isPresented
         self.detents = detents
         self.prefersGrabberVisible = prefersGrabberVisible
+        self.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
@@ -40,6 +43,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         item: Binding<T?>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
+        largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -53,6 +57,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         self.detents = detents
         self.prefersGrabberVisible = prefersGrabberVisible
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
+         self.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
         self.contentView = contentView()
@@ -75,6 +80,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
                 isPresented: $isPresented,
                 detents: detents,
                 prefersGrabberVisible: prefersGrabberVisible,
+                largestUndimmedDetentIdentifier: largestUndimmedDetentIdentifier,
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
@@ -97,6 +103,7 @@ extension View {
     ///   - isPresented: A binding to a Boolean value that determines whether to present the sheet that you create in the modifier’s content closure.
     ///   - detents: An array containing all of the possible sizes for the sheet. This array must contain at least one element. When you set this value, specify detents in order from smallest to largest height.
     ///   - prefersGrabberVisible: A Boolean value that determines whether the sheet shows a grabber at the top.
+    ///   - largestUndimmedDetentIdentifier: The largest detent that doesn't dim the view underneath the sheet.
     ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value that determines whether scrolling expands the sheet to a larger detent.
     ///   - prefersEdgeAttachedInCompactHeight: A Boolean value that determines whether the sheet attaches to the bottom edge of the screen in a compact-height size class.
     ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value that determines whether the sheet's width matches its view controller's preferred content size.
@@ -105,6 +112,7 @@ extension View {
         isPresented: Binding<Bool>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
+        largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -115,6 +123,7 @@ extension View {
                 isPresented: isPresented,
                 detents: detents,
                 prefersGrabberVisible: prefersGrabberVisible,
+                largestUndimmedDetentIdentifier:  largestUndimmedDetentIdentifier,
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
@@ -129,6 +138,7 @@ extension View {
     ///   - item: A binding to an Optional item that determines whether to present the sheet that you create in the modifier’s content closure.
     ///   - detents: An array containing all of the possible sizes for the sheet. This array must contain at least one element. When you set this value, specify detents in order from smallest to largest height.
     ///   - prefersGrabberVisible: A Boolean value that determines whether the sheet shows a grabber at the top.
+    ///   - largestUndimmedDetentIdentifier: The largest detent that doesn't dim the view underneath the sheet.
     ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value that determines whether scrolling expands the sheet to a larger detent.
     ///   - prefersEdgeAttachedInCompactHeight: A Boolean value that determines whether the sheet attaches to the bottom edge of the screen in a compact-height size class.
     ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value that determines whether the sheet's width matches its view controller's preferred content size.
@@ -137,6 +147,7 @@ extension View {
         item: Binding<T?>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
+        largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -147,6 +158,7 @@ extension View {
                 item: item,
                 detents: detents,
                 prefersGrabberVisible: prefersGrabberVisible,
+                largestUndimmedDetentIdentifier:  largestUndimmedDetentIdentifier,
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,

--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -11,7 +11,6 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
     @Binding private var isPresented: Bool
     private let detents: [UISheetPresentationController.Detent]
     private let prefersGrabberVisible: Bool
-    private let smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier?
     private let prefersScrollingExpandsWhenScrolledToEdge: Bool
     private let prefersEdgeAttachedInCompactHeight: Bool
     private let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
@@ -23,7 +22,6 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         isPresented: Binding<Bool>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
-        smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -32,7 +30,6 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         _isPresented = isPresented
         self.detents = detents
         self.prefersGrabberVisible = prefersGrabberVisible
-        self.smallestUndimmedDetentIdentifier = smallestUndimmedDetentIdentifier
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
@@ -43,7 +40,6 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         item: Binding<T?>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
-        smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -56,7 +52,6 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         })
         self.detents = detents
         self.prefersGrabberVisible = prefersGrabberVisible
-        self.smallestUndimmedDetentIdentifier = smallestUndimmedDetentIdentifier
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
@@ -80,7 +75,6 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
                 isPresented: $isPresented,
                 detents: detents,
                 prefersGrabberVisible: prefersGrabberVisible,
-                smallestUndimmedDetentIdentifier: smallestUndimmedDetentIdentifier,
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
@@ -103,7 +97,6 @@ extension View {
     ///   - isPresented: A binding to a Boolean value that determines whether to present the sheet that you create in the modifier’s content closure.
     ///   - detents: An array containing all of the possible sizes for the sheet. This array must contain at least one element. When you set this value, specify detents in order from smallest to largest height.
     ///   - prefersGrabberVisible: A Boolean value that determines whether the sheet shows a grabber at the top.
-    ///   - smallestUndimmedDetentIdentifier: The smallest detent that doesn't dim the view underneath the sheet.
     ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value that determines whether scrolling expands the sheet to a larger detent.
     ///   - prefersEdgeAttachedInCompactHeight: A Boolean value that determines whether the sheet attaches to the bottom edge of the screen in a compact-height size class.
     ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value that determines whether the sheet's width matches its view controller's preferred content size.
@@ -112,7 +105,6 @@ extension View {
         isPresented: Binding<Bool>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
-        smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -123,7 +115,6 @@ extension View {
                 isPresented: isPresented,
                 detents: detents,
                 prefersGrabberVisible: prefersGrabberVisible,
-                smallestUndimmedDetentIdentifier: smallestUndimmedDetentIdentifier,
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
@@ -138,7 +129,6 @@ extension View {
     ///   - item: A binding to an Optional item that determines whether to present the sheet that you create in the modifier’s content closure.
     ///   - detents: An array containing all of the possible sizes for the sheet. This array must contain at least one element. When you set this value, specify detents in order from smallest to largest height.
     ///   - prefersGrabberVisible: A Boolean value that determines whether the sheet shows a grabber at the top.
-    ///   - smallestUndimmedDetentIdentifier: The smallest detent that doesn't dim the view underneath the sheet.
     ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value that determines whether scrolling expands the sheet to a larger detent.
     ///   - prefersEdgeAttachedInCompactHeight: A Boolean value that determines whether the sheet attaches to the bottom edge of the screen in a compact-height size class.
     ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value that determines whether the sheet's width matches its view controller's preferred content size.
@@ -147,7 +137,6 @@ extension View {
         item: Binding<T?>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
-        smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -158,7 +147,6 @@ extension View {
                 item: item,
                 detents: detents,
                 prefersGrabberVisible: prefersGrabberVisible,
-                smallestUndimmedDetentIdentifier: smallestUndimmedDetentIdentifier,
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,

--- a/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
+++ b/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
@@ -14,7 +14,6 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
 
     private let detents: [UISheetPresentationController.Detent]
     private let prefersGrabberVisible: Bool
-    private let smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier?
     private let prefersScrollingExpandsWhenScrolledToEdge: Bool
     private let prefersEdgeAttachedInCompactHeight: Bool
     private let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
@@ -25,7 +24,6 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
         isPresented: Binding<Bool>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
-        smallestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -35,7 +33,6 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
 
         self.detents = detents
         self.prefersGrabberVisible = prefersGrabberVisible
-        self.smallestUndimmedDetentIdentifier = smallestUndimmedDetentIdentifier
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
@@ -67,7 +64,6 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
         if let presentationController = presentationController as? UISheetPresentationController {
             presentationController.detents = detents
             presentationController.prefersGrabberVisible = prefersGrabberVisible
-            presentationController.smallestUndimmedDetentIdentifier = smallestUndimmedDetentIdentifier
             presentationController.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
             presentationController.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
             presentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached

--- a/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
+++ b/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
@@ -14,6 +14,7 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
 
     private let detents: [UISheetPresentationController.Detent]
     private let prefersGrabberVisible: Bool
+    private let largestUndimmedDetentIdentifier: UISheetPresentationController.Detent.Identifier?
     private let prefersScrollingExpandsWhenScrolledToEdge: Bool
     private let prefersEdgeAttachedInCompactHeight: Bool
     private let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
@@ -24,6 +25,7 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
         isPresented: Binding<Bool>,
         detents: [UISheetPresentationController.Detent] = [.medium(), .large()],
         prefersGrabberVisible: Bool = false,
+        largestUndimmedDetentIdentifier:  UISheetPresentationController.Detent.Identifier? = nil,
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
@@ -33,6 +35,7 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
 
         self.detents = detents
         self.prefersGrabberVisible = prefersGrabberVisible
+        self.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
@@ -65,6 +68,7 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
             presentationController.detents = detents
             presentationController.prefersGrabberVisible = prefersGrabberVisible
             presentationController.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
+            presentationController.largestUndimmedDetentIdentifier = largestUndimmedDetentIdentifier
             presentationController.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
             presentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
         }


### PR DESCRIPTION
Removed smallestUndimmedDetentIdentifier because it has been deprecated as of Xcode 13 beta 3. There doesn't appear to be any replacement for it.


https://developer.apple.com/documentation/uikit/uisheetpresentationcontroller/3801909-smallestundimmeddetentidentifier?changes=_2_1