### PR TITLE
Disables the Ability to Dismiss a Presentation

### DIFF
--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -16,6 +16,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
     private let prefersScrollingExpandsWhenScrolledToEdge: Bool
     private let prefersEdgeAttachedInCompactHeight: Bool
     private let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
+    private let isModalInPresentation: Bool
     private var onDismiss: (() -> Void)?
     private let contentView: ContentView
     
@@ -29,6 +30,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
+        isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder contentView: () -> ContentView
     ) {
@@ -39,6 +41,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
+        self.isModalInPresentation = isModalInPresentation
         self.contentView = contentView()
         self.onDismiss = onDismiss
     }
@@ -51,6 +54,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
+        isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder contentView: () -> ContentView
      ) {
@@ -65,6 +69,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         self.prefersScrollingExpandsWhenScrolledToEdge = prefersScrollingExpandsWhenScrolledToEdge
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
+        self.isModalInPresentation = isModalInPresentation
         self.contentView = contentView()
      }
 
@@ -89,6 +94,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
+                isModalInPresentation: isModalInPresentation,
                 content: contentView
             )
 
@@ -113,6 +119,7 @@ extension View {
     ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value that determines whether scrolling expands the sheet to a larger detent.
     ///   - prefersEdgeAttachedInCompactHeight: A Boolean value that determines whether the sheet attaches to the bottom edge of the screen in a compact-height size class.
     ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value that determines whether the sheet's width matches its view controller's preferred content size.
+    ///   - isModalInPresentation: A Boolean value indicating whether the view controller enforces a modal behavior.
     ///   - onDismiss: The closure to execute when dismissing the sheet.
     ///   - contentView: A closure that returns the content of the sheet.
     public func bottomSheet<ContentView: View>(
@@ -123,6 +130,7 @@ extension View {
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
+        isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder contentView: () -> ContentView
     ) -> some View {
@@ -134,6 +142,7 @@ extension View {
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
+                isModalInPresentation: isModalInPresentation,
                 onDismiss: onDismiss,
                 contentView: contentView
             )
@@ -150,6 +159,7 @@ extension View {
     ///   - prefersScrollingExpandsWhenScrolledToEdge: A Boolean value that determines whether scrolling expands the sheet to a larger detent.
     ///   - prefersEdgeAttachedInCompactHeight: A Boolean value that determines whether the sheet attaches to the bottom edge of the screen in a compact-height size class.
     ///   - widthFollowsPreferredContentSizeWhenEdgeAttached: A Boolean value that determines whether the sheet's width matches its view controller's preferred content size.
+    ///   - isModalInPresentation: A Boolean value indicating whether the view controller enforces a modal behavior.
     ///   - onDismiss: The closure to execute when dismissing the sheet.
     ///   - contentView: A closure that returns the content of the sheet.
     public func bottomSheet<T: Any, ContentView: View>(
@@ -160,6 +170,7 @@ extension View {
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
+        isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder contentView: () -> ContentView
     ) -> some View {
@@ -171,6 +182,7 @@ extension View {
                 prefersScrollingExpandsWhenScrolledToEdge: prefersScrollingExpandsWhenScrolledToEdge,
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
+                isModalInPresentation: isModalInPresentation,
                 onDismiss: onDismiss,
                 contentView: contentView
             )

--- a/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
+++ b/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
@@ -29,6 +29,7 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
         prefersScrollingExpandsWhenScrolledToEdge: Bool = true,
         prefersEdgeAttachedInCompactHeight: Bool = false,
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
+        isModalInPresentation: Bool = false,
         content: Content
     ) {
         _isPresented = isPresented
@@ -43,6 +44,7 @@ class BottomSheetViewController<Content: View>: UIViewController, UISheetPresent
         self.contentView = UIHostingController(rootView: content)
 
         super.init(nibName: nil, bundle: nil)
+        self.isModalInPresentation = isModalInPresentation
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
Adds a new `isModalInPresentation` parameter to the initializers. Setting this to true allows the user to disable dismissal of  the sheet.