### PR TITLE
Allow import into projects with min target < iOS 15, presentedViewController chaining fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "BottomSheet",
     platforms: [
-        .iOS("15.0"),
-        .macCatalyst("15.0")
+        .iOS("13.0"),
+        .macCatalyst("13.0")
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -79,7 +79,9 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
             $0.activationState == .foregroundActive
         }) as? UIWindowScene else { return }
 
-        guard let rootViewController = windowScene.keyWindow?.rootViewController else { return }
+        guard let rootViewController = windowScene.keyWindow?.rootViewController?.presentedViewController
+            ?? windowScene.keyWindow?.rootViewController
+        else { return }
 
         if isPresented {
             bottomSheetViewController = BottomSheetViewController(

--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -79,9 +79,12 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
             $0.activationState == .foregroundActive
         }) as? UIWindowScene else { return }
 
-        guard let rootViewController = windowScene.keyWindow?.rootViewController?.presentedViewController
-            ?? windowScene.keyWindow?.rootViewController
-        else { return }
+        
+        guard let root = windowScene.keyWindow?.rootViewController else { return }
+        var controllerToPresentFrom = root
+        while let presented = controllerToPresentFrom.presentedViewController {
+            controllerToPresentFrom = presented
+        }
 
         if isPresented {
             bottomSheetViewController = BottomSheetViewController(
@@ -95,7 +98,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
                 content: contentView
             )
 
-            rootViewController.present(bottomSheetViewController!, animated: true)
+            controllerToPresentFrom.present(bottomSheetViewController!, animated: true)
 
         } else {
             onDismiss?()

--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 15, *)
 struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
     @Binding private var isPresented: Bool
     
@@ -101,6 +102,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
     }
 }
 
+@available(iOS 15, *)
 extension View {
 
     /// Presents a bottom sheet when the binding to a Boolean value you provide is true. The bottom sheet

--- a/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
+++ b/Sources/BottomSheet/View Controllers/BottomSheetViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SwiftUI
 import Combine
 
+@available(iOS 15, *)
 class BottomSheetViewController<Content: View>: UIViewController, UISheetPresentationControllerDelegate {
     @Binding private var isPresented: Bool
 


### PR DESCRIPTION
I had a use for this package in a project that cannot require iOS 15 yet, though current config didn't allow for that use case. Setting an older minimum for the package but annotating the views and extensions with `@available(iOS 15, *)` keeps usage as intended.

Also found an issue where in a stack of presented view controllers the bottom sheet would not be presented, this is because the view controller this bottom sheet would be presented from is not at the top of the stack. Fix was just to follow the `.presentedViewController` chain to find the top most presented view controller.