### PR TITLE
Fix missing content view on first render

### DIFF
--- a/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/Modifiers/BottomSheetModifier.swift
@@ -19,7 +19,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
     private let widthFollowsPreferredContentSizeWhenEdgeAttached: Bool
     private let isModalInPresentation: Bool
     private var onDismiss: (() -> Void)?
-    private let contentView: ContentView
+    private let contentView: () -> ContentView
     
     @State private var bottomSheetViewController: BottomSheetViewController<ContentView>?
 
@@ -33,7 +33,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
         isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder contentView: () -> ContentView
+        @ViewBuilder contentView: @escaping () -> ContentView
     ) {
         _isPresented = isPresented
         self.detents = detents
@@ -43,7 +43,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
         self.isModalInPresentation = isModalInPresentation
-        self.contentView = contentView()
+        self.contentView = contentView
         self.onDismiss = onDismiss
     }
     
@@ -57,7 +57,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
         isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder contentView: () -> ContentView
+        @ViewBuilder contentView: @escaping () -> ContentView
      ) {
         self._isPresented = Binding<Bool>(get: {
             item.wrappedValue != nil
@@ -71,7 +71,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
         self.prefersEdgeAttachedInCompactHeight = prefersEdgeAttachedInCompactHeight
         self.widthFollowsPreferredContentSizeWhenEdgeAttached = widthFollowsPreferredContentSizeWhenEdgeAttached
         self.isModalInPresentation = isModalInPresentation
-        self.contentView = contentView()
+        self.contentView = contentView
      }
 
     func body(content: Content) -> some View {
@@ -101,7 +101,7 @@ struct BottomSheet<T: Any, ContentView: View>: ViewModifier {
                 prefersEdgeAttachedInCompactHeight: prefersEdgeAttachedInCompactHeight,
                 widthFollowsPreferredContentSizeWhenEdgeAttached: widthFollowsPreferredContentSizeWhenEdgeAttached,
                 isModalInPresentation: isModalInPresentation,
-                content: contentView
+                content: contentView()
             )
 
             controllerToPresentFrom.present(bottomSheetViewController!, animated: true)
@@ -139,7 +139,7 @@ extension View {
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
         isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder contentView: () -> ContentView
+        @ViewBuilder contentView: @escaping () -> ContentView
     ) -> some View {
         self.modifier(
             BottomSheet<Any, ContentView>(
@@ -179,7 +179,7 @@ extension View {
         widthFollowsPreferredContentSizeWhenEdgeAttached: Bool = false,
         isModalInPresentation: Bool = false,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder contentView: () -> ContentView
+        @ViewBuilder contentView: @escaping () -> ContentView
     ) -> some View {
         self.modifier(
             BottomSheet(


### PR DESCRIPTION
This PR fixes the bug where the content view is missing on the first render. Basically, the content view is not built during initialization. Instead, it is built when it is passed to the view controller.

This fixes both #10 and #11.